### PR TITLE
Update cyclusnv URL to newly changed website URL

### DIFF
--- a/wastecollectionProvider_4.js
+++ b/wastecollectionProvider_4.js
@@ -44,7 +44,7 @@
 				writeWasteDates(wasteDatesString, enableCreateICS);
 			}
 		} 
-		xmlhttp.open("GET", "https://afvalkalender.cyclusnv.nl/ical/" + wasteICSId, true);
+		xmlhttp.open("GET", "https://cyclusnv.nl/ical/" + wasteICSId, true);
 		xmlhttp.send();
 	}
 


### PR DESCRIPTION
The ical URL for Cyclus NV has changed on their website. The old one does not redirect to the new one and instead just redirects to the main page of Cyclus. This of course means the iCal cannot be retrieved, which causes the wastecollection app to fail.

I fixed this locally on my own Toon and this fix is tested to work. 

Thanks for making and sharing the wastecollection app, I use it everyday. Highly appreciate it!